### PR TITLE
Remove stray dots in site footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 
   <footer class="site-footer">
     <p>
-      &copy; 2026 TeXackers &middot;
+      &copy; 2026 TeXackers
     </p>
     <p>
       <span><a href="https://github.com/TeXackers">GitHub</a></span>

--- a/members.html
+++ b/members.html
@@ -95,7 +95,7 @@
 
   <footer class="site-footer">
     <p>
-      &copy; 2026 TeXackers &middot;
+      &copy; 2026 TeXackers
     </p>
     <p>
       <span><a href="https://github.com/TeXackers">GitHub</a></span>

--- a/projects.html
+++ b/projects.html
@@ -86,7 +86,7 @@
 
   <footer class="site-footer">
     <p>
-      &copy; 2026 TeXackers &middot;
+      &copy; 2026 TeXackers
     </p>
     <p>
       <span><a href="https://github.com/TeXackers">GitHub</a></span>


### PR DESCRIPTION
Removed a stray dot in the site footer next to the TeXackers copyright text in the following files:
- index.html
- members.html
- projects.html