### PR TITLE
Add query-astro to Projects page

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -58,6 +58,14 @@
       </div>
 
       <div class="repo-card">
+        <h3><a class="mono-link" href="https://texackers.dev/query-astro">query-astro</a></h3>
+        <div class="repo-meta">
+          <span><a href="https://github.com/TeXackers/query-astro">GitHub</a></span>
+          <span><a href="https://ctan.org/pkg/query-astro">CTAN</a></span>
+        </div>
+      </div>
+
+      <div class="repo-card">
         <h3><a class="mono-link" href="https://texackers.dev/tabularray">tabularray</a></h3>
         <div class="repo-meta">
           <span><a href="https://github.com/TeXackers/tabularray">GitHub</a></span>


### PR DESCRIPTION
Added package `query-astro` to the list of packages under TeXackers.

Resolves #9. 